### PR TITLE
Enable Routes with security specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The parameters are:
 
 The `AddRequestHandler` function of the router is used to add a function for a specific path and method to the router.
 
+If an endpoint defines a security requirement, `AddRequestHandlerWithAuthFunc` must be used in order to enable the 
+router to check if the user is authorized to access the endpoint. Using the `openapi3filter.NoopAuthenticationFunc` 
+as `authFunc` will grant access for any request without further checks. 
+
 ### Error handling
 If the handler function returns an error, it will be mapped to a corresponding response. Therefore, a custom `HTTPError`
 is used and returned as a JSON response. It contains the following fields:
@@ -126,6 +130,7 @@ func main() {
 		panic(err)
 	}
 	// Add implementation for endpoint specified in OpenAPI specification
+	// Use router.AddRequestHandlerWithAuthFunc if the endpoint defines security requirements
 	router.AddRequestHandler(http.MethodGet, "/test/{client}", HandleRequest)
 	// Add error mapping for MyCustomError
 	router.AddErrorMapping(&MyCustomError{}, http.StatusBadGateway, "could not load data")

--- a/handler.go
+++ b/handler.go
@@ -1,10 +1,13 @@
 package openapirouter
 
 import (
+	"github.com/getkin/kin-openapi/openapi3filter"
 	"net/http"
 )
 
-const pathParamsKey = "pathParams"
+type contextKey int
+
+const pathParamsKey contextKey = iota
 
 // HandleRequestFunction is a custom function to specify the implementation of an HTTP endpoint. It does not receive the
 // http.ResponseWriter for the request since it is written by the requestHandler. The content of this response is
@@ -18,6 +21,7 @@ type HandleRequestFunction = func(*http.Request, map[string]string) (*Response, 
 type requestHandler struct {
 	errMapper       *errorMapper
 	handlerFunction HandleRequestFunction
+	options         *openapi3filter.Options
 }
 
 // implementation of http.Handler that extracts the pathParameters from the request's context and invokes the

--- a/testdata/test-api.yaml
+++ b/testdata/test-api.yaml
@@ -52,6 +52,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TestData'
+  /test/secured:
+    get:
+      security:
+        - apiKey: []
+      responses:
+        200:
+          description: "Successful"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestData'
 components:
   schemas:
     TestEnum:
@@ -68,3 +79,8 @@ components:
           type: string
           example: "test"
           description: "just a test"
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      name: x-api-key
+      in: header


### PR DESCRIPTION
If a resource method specified in the OpenAPI-YAML contains a security specification (API-Key, JWT, etc.), the `openapi3filter.ValidateRequest` func use an `openapi3filter.AuthenticationFunc` to determine if the client is authorized to access the method. If this function is not specified, the Request-Validation will fail and the router will return a response with status code `500 - InternalServerError`. 

Thus the ability to set this `openapi3filter.AuthenticationFunc` for a request handler is needed. The authentication process can be skipped by adding the `openapi3filter.NoopAuthenticationFunc` which will grant access for every request without further validation.